### PR TITLE
Fix error accessing private workload cluster console via VPN

### DIFF
--- a/110-ibm-fs-edge-vpc/terraform/variables.tf
+++ b/110-ibm-fs-edge-vpc/terraform/variables.tf
@@ -568,7 +568,7 @@ variable "ibm-vpn-server_vpnclient_ip" {
 variable "ibm-vpn-server_vpc_cidr" {
   type = string
   description = "CIDR for the private VPC the VPN is connected to."
-  default = "10.0.0.0/12"
+  default = "10.0.0.0/8"
 }
 variable "ibm-vpn-server_dns_cidr" {
   type = string


### PR DESCRIPTION
- Expand default ibm-vpn-server-vpc_cidr to include all the subnets within the vpc (CIDR from /12 to /8)

closes #26