### PR TITLE
updated default ocp version from 4.8 ➞ 4.10; added .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ credentials.properties
 
 .history/*
 .DS_Store
+
+.vscode

--- a/130-ibm-fs-management-vpc-openshift/bom.yaml
+++ b/130-ibm-fs-management-vpc-openshift/bom.yaml
@@ -147,7 +147,7 @@ spec:
         - name: worker_count
           alias: mgmt_worker_count
         - name: ocp_version
-          value: 4.8
+          value: 4.10
       dependencies:
         - name: subnets
           ref: worker-subnets

--- a/130-ibm-fs-management-vpc-openshift/terraform/variables.tf
+++ b/130-ibm-fs-management-vpc-openshift/terraform/variables.tf
@@ -348,7 +348,7 @@ variable "cluster_flavor" {
 variable "ocp_version" {
   type = string
   description = "The version of the OpenShift cluster that should be provisioned (format 4.x)"
-  default = "4.8"
+  default = "4.10"
 }
 variable "cluster_exists" {
   type = bool

--- a/150-ibm-fs-workload-vpc-openshift/bom.yaml
+++ b/150-ibm-fs-workload-vpc-openshift/bom.yaml
@@ -150,7 +150,7 @@ spec:
         - name: worker_count
           alias: workload_worker_count
         - name: ocp_version
-          value: 4.8
+          value: 4.10
       dependencies:
         - name: subnets
           ref: worker-subnets

--- a/150-ibm-fs-workload-vpc-openshift/terraform/variables.tf
+++ b/150-ibm-fs-workload-vpc-openshift/terraform/variables.tf
@@ -348,7 +348,7 @@ variable "cluster_flavor" {
 variable "ocp_version" {
   type = string
   description = "The version of the OpenShift cluster that should be provisioned (format 4.x)"
-  default = "4.8"
+  default = "4.10"
 }
 variable "cluster_exists" {
   type = bool


### PR DESCRIPTION
Minimum Red Hat OpenShift version on IBM Cloud is now 4.10